### PR TITLE
fix(pokedex): correct Aggron type order and add Mega Lopunny types

### DIFF
--- a/src/utils/formatters/matchSpeciesToTypes.ts
+++ b/src/utils/formatters/matchSpeciesToTypes.ts
@@ -535,6 +535,16 @@ export const handleSpeciesTypeEdgeCases = ({
         return [Types.Normal, Types.Fighting];
     }
 
+    if (
+        match({
+            ...data,
+            species: ["Lopunny"],
+            forme: ["Mega"],
+        })
+    ) {
+        return [Types.Normal, Types.Fighting];
+    }
+
     if (match({ ...data, species: ["Growlithe"], forme: ["Hisuian"] })) {
         return [Types.Fire, Types.Rock];
     }
@@ -1650,7 +1660,7 @@ export const matchSpeciesToTypes = (
         case "Aron":
         case "Lairon":
         case "Aggron":
-            return [Types.Rock, Types.Steel];
+            return [Types.Steel, Types.Rock];
         case "Gulpin":
         case "Swalot":
             return [Types.Poison, Types.Poison];


### PR DESCRIPTION
## Summary

Two Pokédex data fixes for the **Porygon** milestone:

### `#1162` — Aggron types in wrong order
- Changed from `Rock/Steel` to `Steel/Rock`
- Matches canonical game data where Steel is Aggron's primary type

### `#1156` — Mega Lopunny missing Fighting type  
- Added `Normal/Fighting` type override in `handleSpeciesTypeEdgeCases`
- Previously fell through to the main switch which returned `Normal/Normal`

Closes #1162
Closes #1156