### PR TITLE
Fix result image download cropping

### DIFF
--- a/src/components/Features/Result/Result.tsx
+++ b/src/components/Features/Result/Result.tsx
@@ -43,6 +43,7 @@ import { resultSelector } from "selectors";
 import { PokemonImage } from "components/Common/Shared/PokemonImage";
 import { normalizeSpeciesName } from "utils/getters/normalizeSpeciesName";
 import { Select } from "@blueprintjs/select";
+import { getResultImageDownloadOptions } from "./downloadImage";
 
 async function load() {
     const resource = await import("@emmaramirez/dom-to-image");
@@ -205,10 +206,15 @@ export class ResultBase extends React.PureComponent<ResultProps, ResultState> {
         const resultNode = this.resultRef.current;
         this.setState({ isDownloading: true });
         try {
+            if (!resultNode) {
+                throw new Error("Result node is not available for download.");
+            }
+
             const domToImage = await load();
-            const dataUrl = await domToImage.toPng(resultNode, {
-                corsImage: true,
-            });
+            const dataUrl = await domToImage.toPng(
+                resultNode,
+                getResultImageDownloadOptions(resultNode),
+            );
             console.log(dataUrl, resultNode);
             const link = document.createElement("a");
             link.download = `nuzlocke-${uuid()}.png`;

--- a/src/components/Features/Result/Result2.tsx
+++ b/src/components/Features/Result/Result2.tsx
@@ -23,6 +23,10 @@ import { TrainerResult } from "./TrainerResult";
 import { getContrastColor } from "utils";
 import { useEvent } from "utils/hooks";
 import { TrainerNotes } from "./TrainerNotes";
+import {
+    DomToImageDownloadOptions,
+    getResultImageDownloadOptions,
+} from "./downloadImage";
 
 import { v4 as uuid } from "uuid";
 
@@ -34,7 +38,7 @@ async function load() {
 type DomToImage = {
     toPng: (
         node: HTMLElement,
-        options?: { corsImage?: boolean },
+        options?: DomToImageDownloadOptions,
     ) => Promise<string>;
 };
 
@@ -89,9 +93,10 @@ const toImage =
         try {
             setDS(DownloadStatus.active);
             const domToImage = await load();
-            const dataUrl = await domToImage.toPng(resultNode, {
-                corsImage: true,
-            });
+            const dataUrl = await domToImage.toPng(
+                resultNode,
+                getResultImageDownloadOptions(resultNode),
+            );
             const link = document.createElement("a");
             link.download = `nuzlocke-${uuid()}.png`;
             link.href = dataUrl;

--- a/src/components/Features/Result/__tests__/downloadImage.test.ts
+++ b/src/components/Features/Result/__tests__/downloadImage.test.ts
@@ -1,0 +1,73 @@
+import { getResultImageDownloadOptions } from "../downloadImage";
+
+const setReadOnlyNumber = (
+    node: HTMLElement,
+    property: keyof HTMLElement,
+    value: number,
+) => {
+    Object.defineProperty(node, property, {
+        configurable: true,
+        value,
+    });
+};
+
+describe("getResultImageDownloadOptions", () => {
+    it("exports the full scrollable result instead of the clipped viewport", () => {
+        const node = document.createElement("div");
+        setReadOnlyNumber(node, "clientWidth", 800);
+        setReadOnlyNumber(node, "offsetWidth", 800);
+        setReadOnlyNumber(node, "scrollWidth", 1200);
+        setReadOnlyNumber(node, "clientHeight", 600);
+        setReadOnlyNumber(node, "offsetHeight", 600);
+        setReadOnlyNumber(node, "scrollHeight", 1400);
+
+        const options = getResultImageDownloadOptions(node);
+
+        expect(options.width).toBe(1200);
+        expect(options.height).toBe(1400);
+        expect(options.style.width).toBe("1200px");
+        expect(options.style.height).toBe("1400px");
+        expect(options.style.minHeight).toBe("1400px");
+        expect(options.style.overflow).toBe("visible");
+        expect(options.style.overflowY).toBe("visible");
+    });
+
+    it("removes preview-only positioning and transforms from the cloned image", () => {
+        const node = document.createElement("div");
+        setReadOnlyNumber(node, "clientWidth", 300);
+        setReadOnlyNumber(node, "offsetWidth", 300);
+        setReadOnlyNumber(node, "scrollWidth", 300);
+        setReadOnlyNumber(node, "clientHeight", 200);
+        setReadOnlyNumber(node, "offsetHeight", 200);
+        setReadOnlyNumber(node, "scrollHeight", 200);
+
+        const options = getResultImageDownloadOptions(node);
+
+        expect(options.style.transform).toBe("none");
+        expect(options.style.position).toBe("relative");
+        expect(options.style.left).toBe("0");
+        expect(options.style.top).toBe("0");
+        expect(options.style.margin).toBe("0");
+        expect(options.style.transition).toBe("none");
+    });
+
+    it("uses unscaled layout dimensions instead of preview transform dimensions", () => {
+        const node = document.createElement("div");
+        setReadOnlyNumber(node, "clientWidth", 1000);
+        setReadOnlyNumber(node, "offsetWidth", 1000);
+        setReadOnlyNumber(node, "scrollWidth", 1000);
+        setReadOnlyNumber(node, "clientHeight", 750);
+        setReadOnlyNumber(node, "offsetHeight", 750);
+        setReadOnlyNumber(node, "scrollHeight", 750);
+        node.getBoundingClientRect = () =>
+            ({
+                width: 2000,
+                height: 1500,
+            }) as DOMRect;
+
+        const options = getResultImageDownloadOptions(node);
+
+        expect(options.width).toBe(1000);
+        expect(options.height).toBe(750);
+    });
+});

--- a/src/components/Features/Result/downloadImage.ts
+++ b/src/components/Features/Result/downloadImage.ts
@@ -1,0 +1,70 @@
+export type DomToImageDownloadOptions = {
+    corsImage: boolean;
+    width: number;
+    height: number;
+    style: Record<string, string>;
+};
+
+const positiveCeil = (value: number | undefined) => {
+    if (typeof value !== "number" || !Number.isFinite(value)) return 0;
+
+    return Math.max(0, Math.ceil(value));
+};
+
+const getFallbackRectDimension = (
+    node: HTMLElement,
+    dimension: "width" | "height",
+) => positiveCeil(node.getBoundingClientRect()[dimension]);
+
+const getElementWidth = (node: HTMLElement) => {
+    const layoutWidth = Math.max(
+        positiveCeil(node.scrollWidth),
+        positiveCeil(node.offsetWidth),
+        positiveCeil(node.clientWidth),
+    );
+
+    return Math.max(1, layoutWidth || getFallbackRectDimension(node, "width"));
+};
+
+const getElementHeight = (node: HTMLElement) => {
+    const layoutHeight = Math.max(
+        positiveCeil(node.scrollHeight),
+        positiveCeil(node.offsetHeight),
+        positiveCeil(node.clientHeight),
+    );
+
+    return Math.max(1, layoutHeight || getFallbackRectDimension(node, "height"));
+};
+
+export const getResultImageDownloadOptions = (
+    node: HTMLElement,
+): DomToImageDownloadOptions => {
+    const width = getElementWidth(node);
+    const height = getElementHeight(node);
+
+    return {
+        corsImage: true,
+        width,
+        height,
+        style: {
+            bottom: "auto",
+            height: `${height}px`,
+            left: "0",
+            margin: "0",
+            maxHeight: "none",
+            maxWidth: "none",
+            minHeight: `${height}px`,
+            minWidth: `${width}px`,
+            overflow: "visible",
+            overflowX: "visible",
+            overflowY: "visible",
+            position: "relative",
+            right: "auto",
+            top: "0",
+            transform: "none",
+            transformOrigin: "0 0",
+            transition: "none",
+            width: `${width}px`,
+        },
+    };
+};


### PR DESCRIPTION
## Summary
- Add shared dom-to-image download options for result exports.
- Capture the full scrollable result dimensions instead of the clipped viewport.
- Reset preview-only margin, positioning, transform, transition, and overflow on the cloned export node.
- Apply the same download sizing path to Result and Result2.

Refs ART-13 and GitHub issues #212, #806, #725, #538, #411, #480.

## Validation
- `npm run typecheck`
- `npm run lint`
- `npm run test:run -- src/components/Features/Result/__tests__/downloadImage.test.ts`
- `npm run build`
- Playwright local verification with the #806/#538/#411/#480 issue states: fixed-height examples now export using full scroll height (#411: 939px vs 870px viewport; #480: 1090px vs 1040px viewport), and successful #806/#538 downloads matched result dimensions.